### PR TITLE
Add support for filters

### DIFF
--- a/lib/one_signal/param.ex
+++ b/lib/one_signal/param.ex
@@ -1,7 +1,7 @@
 defmodule OneSignal.Param do
   alias OneSignal.Param
 
-  defstruct messages: %{}, headings: nil, platforms: nil, included_segments: nil, excluded_segments: nil, include_player_ids: nil, exclude_player_ids: nil, tags: nil, data: nil, ios_params: nil, android_params: nil, adm_params: nil, wp_params: nil, chrome_params: nil, firefox_params: nil, send_after: nil
+  defstruct messages: %{}, headings: nil, platforms: nil, included_segments: nil, excluded_segments: nil, include_player_ids: nil, exclude_player_ids: nil, tags: nil, filters: nil, data: nil, ios_params: nil, android_params: nil, adm_params: nil, wp_params: nil, chrome_params: nil, firefox_params: nil, send_after: nil
 
   defp to_string_key({k, v}) do
     {to_string(k), v}
@@ -183,6 +183,22 @@ defmodule OneSignal.Param do
 
   def put_data(%Param{data: data} = param, key, value) do
     %{param | data: Map.put(data, key, value)}
+  end
+
+  @doc """
+  Put player id
+  """
+  def put_filter(%Param{filters: nil} = param, filter) do
+    %{param | filters: [filter]}
+  end
+  def put_filter(%Param{filters: ids} = param, filter) do
+    %{param | filters: [filter|ids]}
+  end
+
+  def put_filters(%Param{} = param, filters) when is_list(filters) do
+    Enum.reduce(filters, param, fn next, acc ->
+      put_filter(acc, next)
+    end)
   end
 
 end

--- a/lib/one_signal/param.ex
+++ b/lib/one_signal/param.ex
@@ -191,8 +191,8 @@ defmodule OneSignal.Param do
   def put_filter(%Param{filters: nil} = param, filter) do
     %{param | filters: [filter]}
   end
-  def put_filter(%Param{filters: ids} = param, filter) do
-    %{param | filters: [filter|ids]}
+  def put_filter(%Param{filters: filters} = param, filter) do
+    %{param | filters: [filter|filters]}
   end
 
   def put_filters(%Param{} = param, filters) when is_list(filters) do

--- a/mix.exs
+++ b/mix.exs
@@ -9,9 +9,9 @@ defmodule OneSignal.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
      description: @description,
-     package: package]
+     package: package()]
   end
 
   # Configuration for the OTP application

--- a/test/one_signal/param_test.exs
+++ b/test/one_signal/param_test.exs
@@ -110,4 +110,9 @@ defmodule OneSignal.ParamTest do
     assert world == "World!"
   end
 
+  test "put filter" do
+    param = put_filter(OneSignal.new, %{field: "tag", key: "user", relation: "=", value: "12"})
+    refute Enum.empty?(param.filters)
+  end
+
 end


### PR DESCRIPTION
See: https://documentation.onesignal.com/reference#section-send-to-users-based-on-filters

Filters can be put with `put_filter/2`.
