### PR TITLE
Add dynamic `json_library` config like phoenix.

### DIFF
--- a/lib/one_signal.ex
+++ b/lib/one_signal.ex
@@ -25,7 +25,7 @@ defmodule OneSignal do
   end
 
   defp config do
-    Application.get_env(:one_signal, OneSignal)
+    Application.get_env(:one_signal, OneSignal, %{})
   end
 
   defp fetch_api_key do
@@ -34,5 +34,10 @@ defmodule OneSignal do
 
   def fetch_app_id do
     config()[:app_id] || System.get_env("ONE_SIGNAL_APP_ID")
+  end
+
+  @spec json_library :: any
+  def json_library do
+    Application.get_env(:one_signal, :json_library, Poison)
   end
 end

--- a/lib/one_signal/api.ex
+++ b/lib/one_signal/api.ex
@@ -1,4 +1,5 @@
 defmodule OneSignal.API do
+  @json_library OneSignal.json_library()
 
   def get(url, query \\ []) do
     HTTPoison.start
@@ -15,7 +16,7 @@ defmodule OneSignal.API do
   def post(url, body) do
     HTTPoison.start
 
-    req_body = Poison.encode!(body)
+    req_body = @json_library.encode!(body)
 
     HTTPoison.post!(url, req_body, OneSignal.auth_header)
     |> handle_response
@@ -28,11 +29,11 @@ defmodule OneSignal.API do
   end
 
   defp handle_response(%HTTPoison.Response{body: body, status_code: code}) when code in 200..299 do
-    {:ok, Poison.decode!(body)}
+    {:ok, @json_library.decode!(body)}
   end
 
   defp handle_response(%HTTPoison.Response{body: body, status_code: _}) do
-    {:error, Poison.decode!(body)}
+    {:error, @json_library.decode!(body)}
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule OneSignal.Mixfile do
 
   defp deps() do
     [
-      {:poison, "~> 3.1.0"},
+      {:poison, "~> 3.1.0", optional: true},
       {:httpoison, "~> 1.5.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]


### PR DESCRIPTION
I'm currently working on a client project where everything uses the `Jason` json library. I have added a config option that allows you to specify a json library, while defaulting to Poison.

```
config :one_signal, json_library: Jason
```