### PR TITLE
Add url to OneSignal.Param struct.

### DIFF
--- a/lib/one_signal/param.ex
+++ b/lib/one_signal/param.ex
@@ -239,6 +239,7 @@ defmodule OneSignal.Param do
   @doc """
   Set destination URL.
   """
+  def put_url(param, nil), do: param
   def put_url(param, url) do
     %{param | url: url}
   end

--- a/lib/one_signal/param.ex
+++ b/lib/one_signal/param.ex
@@ -1,7 +1,7 @@
 defmodule OneSignal.Param do
   alias OneSignal.Param
 
-  defstruct android_channel_id: nil, messages: %{}, headings: nil, platforms: nil, included_segments: nil, excluded_segments: nil, include_external_user_ids: nil, exclude_external_user_ids: nil, include_player_ids: nil, exclude_player_ids: nil, filters: [],tags: nil, data: nil, ios_params: nil, android_params: nil, adm_params: nil, wp_params: nil, chrome_params: nil, firefox_params: nil, send_after: nil, url: nil
+  defstruct android_channel_id: nil, messages: %{}, headings: nil, platforms: nil, included_segments: nil, excluded_segments: nil, include_external_user_ids: nil, exclude_external_user_ids: nil, include_player_ids: nil, exclude_player_ids: nil, filters: [],tags: nil, data: nil, ios_params: nil, android_params: nil, adm_params: nil, wp_params: nil, chrome_params: nil, firefox_params: nil, send_after: nil, url: nil, subtitle: nil
 
   defp to_string_key({k, v}) do
     {to_string(k), v}
@@ -242,5 +242,13 @@ defmodule OneSignal.Param do
   def put_url(param, nil), do: param
   def put_url(param, url) do
     %{param | url: url}
+  end
+
+  @doc """
+  Set subtitle.
+  """
+  def put_subtitle(param, nil), do: param
+  def put_subtitle(param, subtitle) do
+    %{param | subtitle: subtitle}
   end
 end

--- a/lib/one_signal/param.ex
+++ b/lib/one_signal/param.ex
@@ -1,7 +1,7 @@
 defmodule OneSignal.Param do
   alias OneSignal.Param
 
-  defstruct android_channel_id: nil, messages: %{}, headings: nil, platforms: nil, included_segments: nil, excluded_segments: nil, include_external_user_ids: nil, exclude_external_user_ids: nil, include_player_ids: nil, exclude_player_ids: nil, filters: [],tags: nil, data: nil, ios_params: nil, android_params: nil, adm_params: nil, wp_params: nil, chrome_params: nil, firefox_params: nil, send_after: nil
+  defstruct android_channel_id: nil, messages: %{}, headings: nil, platforms: nil, included_segments: nil, excluded_segments: nil, include_external_user_ids: nil, exclude_external_user_ids: nil, include_player_ids: nil, exclude_player_ids: nil, filters: [],tags: nil, data: nil, ios_params: nil, android_params: nil, adm_params: nil, wp_params: nil, chrome_params: nil, firefox_params: nil, send_after: nil, url: nil
 
   defp to_string_key({k, v}) do
     {to_string(k), v}
@@ -234,5 +234,12 @@ defmodule OneSignal.Param do
   """
   def set_android_channel_id(param, channel_id) do
     %{param | android_channel_id: channel_id}
+  end
+
+  @doc """
+  Set destination URL.
+  """
+  def put_url(param, url) do
+    %{param | url: url}
   end
 end

--- a/test/one_signal/param_test.exs
+++ b/test/one_signal/param_test.exs
@@ -120,4 +120,11 @@ defmodule OneSignal.ParamTest do
     assert world == "World!"
   end
 
+  test "put url" do
+    url = "https://github.com/yoavlt/one_signal"
+    param = OneSignal.new()
+            |> put_url(url)
+    assert param.url == url
+  end
+
 end


### PR DESCRIPTION
`url` parameter allows to setup a webpage to be opened on a notification click.
On apps it also handles deep links.

[OneSignal documentation](https://documentation.onesignal.com/reference#section-attachments)